### PR TITLE
Add workflow terraform plan

### DIFF
--- a/.github/workflows/continuous-integration-terraform-module-deployment.yml
+++ b/.github/workflows/continuous-integration-terraform-module-deployment.yml
@@ -9,12 +9,32 @@ env:
   MODULE_DEPLOYMENT_DIR: "module-deployment"
 
 jobs:
+  set-env:
+    name: Set environment
+    runs-on: ubuntu-22.04
+    outputs:
+      branch: ${{ steps.var.outputs.branch }}
+    steps:
+      - id: var
+        run: |
+          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+
   terraform-validate:
     name: Terraform Validate
     runs-on: ubuntu-latest
+    needs: set-env
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
       - name: Get terraform version
         id: get-terraform-version
@@ -26,6 +46,15 @@ jobs:
         uses: hashicorp/setup-terraform@v3.0.0
         with:
           terraform_version: ${{ steps.get-terraform-version.outputs.version }}
+
+      - name: Download tfvars and backend
+        run: |
+          aws s3 cp s3://${{ secrets.TFVARS_S3_BUCKET_NAME }}/${{ secrets.TFVARS_FILENAME }} ${{ env.MODULE_DEPLOYMENT_DIR }}/.
+          aws s3 cp s3://${{ secrets.TFVARS_S3_BUCKET_NAME }}/${{ secrets.TF_BACKEND_FILENAME }} ${{ env.MODULE_DEPLOYMENT_DIR }}/.
+
+      - name: Replace module version with branch name
+        run: |
+          sed -i "s/  source = \"github.com\/chris-qa-org\/terraform-aws-tfl-notice-board.*/  source = \"github.com\/chris-qa-org\/terraform-aws-tfl-notice-board?ref=${{ needs.set-env.outputs.branch }}\"/g" ${{ env.MODULE_DEPLOYMENT_DIR }}/tfl-notice-board.tf
 
       - name: Run a Terraform init
         run: |
@@ -41,6 +70,11 @@ jobs:
         run: |
           terraform -chdir=${{ env.MODULE_DEPLOYMENT_DIR }} \
           fmt -check=true -diff=true
+
+      - name: Run a Terraform plan
+        run: |
+          terraform -chdir=${{ env.MODULE_DEPLOYMENT_DIR }} \
+          plan
 
   terraform-docs-validation:
     name: Terraform Docs validation

--- a/module-deployment/.terraform.lock.hcl
+++ b/module-deployment/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.46.0"
+  constraints = ">= 5.9.0"
+  hashes = [
+    "h1:gagAtniijwJRhsKRBWWZfmnPiqu4u1A5oI626+KA/1g=",
+    "zh:05ae6180a7f23071435f6e5e59c19af0b6c5da42ee600c6c1568c8660214d548",
+    "zh:0d878d1565d5e57ce6b34ec5f04b28662044a50c999ec5770c374aa1f1020de2",
+    "zh:25ef1467af2514d8011c44759307445f7057836ff87dfe4503c3e1c9776d5c1a",
+    "zh:26c006df6200f0063b827aab05bec94f9f3f77848e82ed72e48a51d1170d1961",
+    "zh:37cdf4292649a10f12858622826925e18ad4eca354c31f61d02c66895eb91274",
+    "zh:4315b0433c2fc512666c74e989e2d95240934ef370bea1c690d36cb02d30c4ce",
+    "zh:75df0b3f631b78aeff1832cc77d99b527c2a5e79d40f7aac40bdc4a66124dac2",
+    "zh:90693d936c9a556d2bf945de4920ff82052002eb73139bd7164fafd02920f0ef",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c9177ad09804c60fd2ed25950570407b6bdcdf0fcc309e1673b584f06a827fae",
+    "zh:ca8e8db24a4d62d92afd8d3d383b81a08693acac191a2e0a110fb46deeff56a3",
+    "zh:d5fa3a36e13957d63bfe9bbd6df0426a2422214403aac9f20b60c36f8d9ebec6",
+    "zh:e4ede44a112296c9cc77b15e439e41ee15c0e8b3a0dec94ae34df5ebba840e8b",
+    "zh:f2d4de8d8cde69caffede1544ebea74e69fcc4552e1b79ae053519a05c060706",
+    "zh:fc19e9266b1841d4a3aeefa8a5b5ad6988baed6540f85a373b6c2d0dc1ca5830",
+  ]
+}

--- a/module-deployment/README.md
+++ b/module-deployment/README.md
@@ -8,6 +8,7 @@ This project consumes the chris-qa-org/terraform-aws-tfl-notice-board module for
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46.0 |
 
 ## Providers
 
@@ -17,6 +18,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_aws_tfvars_s3"></a> [aws\_tfvars\_s3](#module\_aws\_tfvars\_s3) | github.com/dxw/terraform-aws-tfvars-s3 | v0.2.5 |
 | <a name="module_tfl_notice_board"></a> [tfl\_notice\_board](#module\_tfl\_notice\_board) | github.com/chris-qa-org/terraform-aws-tfl-notice-board | v0.1.0 |
 
 ## Resources
@@ -25,7 +27,11 @@ No resources.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region in which to launch resources | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name | `string` | n/a | yes |
+| <a name="input_tfvars_s3_tfvars_files"></a> [tfvars\_s3\_tfvars\_files](#input\_tfvars\_s3\_tfvars\_files) | Map of objects containing tfvar file paths | <pre>map(<br>    object({<br>      path = string<br>      key  = optional(string, "")<br>      }<br>  ))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/module-deployment/locals.tf
+++ b/module-deployment/locals.tf
@@ -1,2 +1,5 @@
 locals {
+  aws_region             = var.aws_region
+  project_name           = var.project_name
+  tfvars_s3_tfvars_files = var.tfvars_s3_tfvars_files
 }

--- a/module-deployment/provider.tf
+++ b/module-deployment/provider.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = local.aws_region
+  default_tags {
+    tags = {
+      Project = local.project_name
+    }
+  }
+}

--- a/module-deployment/s3-tfvars.tf
+++ b/module-deployment/s3-tfvars.tf
@@ -1,0 +1,8 @@
+module "aws_tfvars_s3" {
+  source = "github.com/dxw/terraform-aws-tfvars-s3?ref=v0.2.5"
+
+  project_name             = "chris-qa-tfl-notice-board"
+  enable_s3_bucket_logging = true
+  logging_bucket_retention = 30
+  tfvars_files             = local.tfvars_s3_tfvars_files
+}

--- a/module-deployment/variables.tf
+++ b/module-deployment/variables.tf
@@ -1,0 +1,20 @@
+variable "aws_region" {
+  description = "AWS region in which to launch resources"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name"
+  type        = string
+}
+
+variable "tfvars_s3_tfvars_files" {
+  description = "Map of objects containing tfvar file paths"
+  type = map(
+    object({
+      path = string
+      key  = optional(string, "")
+      }
+  ))
+  default = {}
+}

--- a/module-deployment/versions.tf
+++ b/module-deployment/versions.tf
@@ -1,5 +1,9 @@
 terraform {
   required_version = ">= 1.8.1"
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.46.0"
+    }
   }
 }


### PR DESCRIPTION
* Adds a `terraform plan` step to the module deployment workflow
* Uses the dxw/terraform-aws-tfvars-s3 module to upload the tfvars and backend so that they can be pulled down via the workflow